### PR TITLE
run become_declustered before normal exit

### DIFF
--- a/impl_pgsql/on_declustered.sh
+++ b/impl_pgsql/on_declustered.sh
@@ -1,3 +1,3 @@
 rm -f /var/lib/pgsql/9.4/data/postgresql.conf
 ln -s /var/lib/pgsql/9.4/data/postgresql.conf.standalone /var/lib/pgsql/9.4/data/postgresql.conf
-/usr/pgsql-9.4/bin/psql -c "select pg_reload_conf()"
+/usr/pgsql-9.4/bin/psql -c "select pg_reload_conf()" 2> /dev/null

--- a/zha.py
+++ b/zha.py
@@ -161,6 +161,9 @@ class ClusterMonitor(threading.Thread):
             self._zk_register()
             self.check_cluster()
             self.trigger()
+        if self.zha.is_clustered:
+            self.zha.config.become_declustered()
+            self.zha.is_clustered = False
         self.zk.delete(self.znode)
         logger.info("cluster monitor thread stopped.")
     def check_cluster(self):


### PR DESCRIPTION
I have found that if the zha process with ACT:HEALTHY:CLUSTERED exits with Ctrl+C, become_declustered is not called.
This is not a problem but I feel this is annoying because we have to do decluster manually even when normal exits.

Regards,