### PR TITLE
[impl_pgsql]check the replication status on health check script

### DIFF
--- a/impl_pgsql/check_health.sh
+++ b/impl_pgsql/check_health.sh
@@ -4,6 +4,10 @@ then
   if [ $? = 0 ] ; then exit 3; fi
   exit 0
 fi
-/usr/pgsql-9.4/bin/psql -c "select 1" > /dev/null 2>&1
-if [ $? = 0 ] ; then exit 2; fi
+ret=0
+psql -c "select 1" > /dev/null 2>&1
+if [ $? = 0 ] ; then ret=1; fi
+state=`psql -c "select sync_state from pg_stat_replication" -t 2> /dev/null`
+if [ -z "$state" ] ; then exit $ret; fi
+[[ $state == 'async' || $state == 'sync' ]] ; exit 2
 exit 0


### PR DESCRIPTION
With this fix, ZHA can recognize the replication status and make ACT to SBY when the replication connection is lost.